### PR TITLE
feat: update ingestion metadata jre examples

### DIFF
--- a/android/java/v1/AmpliApp/app/build.gradle
+++ b/android/java/v1/AmpliApp/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation 'com.amplitude:android-sdk:2.37.0'
+    implementation 'com.amplitude:android-sdk:2.38.2+'
     // https://github.com/amplitude/Amplitude-Android/issues/309
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 

--- a/android/java/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.java
+++ b/android/java/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.java
@@ -15,8 +15,6 @@
 //
 package com.amplitude.ampli;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -118,20 +116,6 @@ public class Ampli {
 
         if (this.client.getConfiguration() != null && this.client.getConfiguration().getPlan() == null) {
             this.client.getConfiguration().setPlan(defaultObservePlan);
-        }
-
-        // set IngestionMetadata with backwards compatibility, min Android Kotlin SDK version 1.2.0.
-        try {
-            Class<?> clazz = Class.forName("com.amplitude.android.events.IngestionMetadata");
-            Constructor<?> clazzConstructor = clazz.getConstructor(String.class, String.class);
-            Object ingestionMetadata = clazzConstructor.newInstance("android-java-ampli", "2.0.0");
-            Class<?> coreClazz = Class.forName("com.amplitude.core.events.IngestionMetadata");
-            Method setIngestionMetadata = Configuration.class.getMethod("setIngestionMetadata", coreClazz);
-            setIngestionMetadata.invoke(this.client.getConfiguration(), ingestionMetadata);
-        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException e) {
-            System.out.println("IngestionMetadata is available starting from Android Kotlin SDK 1.2.0 version");
-        } catch (Exception e) {
-            System.err.println("Unexpected error when setting IngestionMetadata");
         }
     }
 

--- a/android/kotlin/v1/AmpliApp/app/build.gradle
+++ b/android/kotlin/v1/AmpliApp/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation 'com.amplitude:android-sdk:2.37.0'
+    implementation 'com.amplitude:android-sdk:2.38.2+'
     // https://github.com/amplitude/Amplitude-Android/issues/309
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 

--- a/android/kotlin/v1/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
+++ b/android/kotlin/v1/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
@@ -16,13 +16,14 @@
 
 package com.amplitude.ampli
 
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
 import com.amplitude.api.Amplitude
 import com.amplitude.api.AmplitudeClient
 import com.amplitude.api.MiddlewareExtra
 import com.amplitude.api.Plan
-import org.json.JSONArray
-import org.json.JSONException
-import org.json.JSONObject
 
 abstract class Event<E: Event<E>>(
     val eventType: String,
@@ -530,8 +531,7 @@ open class Ampli {
             val ingestionMetadata = clazz.newInstance()
             setSourceNameMethod.invoke(ingestionMetadata, "android-kotlin-ampli")
             setSourceVersionMethod.invoke(ingestionMetadata, "1.0.0")
-            val setIngestionMetadata =
-                AmplitudeClient::class.java.getMethod("setIngestionMetadata", clazz)
+            val setIngestionMetadata = AmplitudeClient::class.java.getMethod("setIngestionMetadata", clazz)
             setIngestionMetadata.invoke(client, ingestionMetadata)
         } catch (e: ClassNotFoundException) {
             println("com.amplitude.api.IngestionMetadata is available starting from Android SDK 2.38.2 version")

--- a/android/kotlin/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
+++ b/android/kotlin/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
@@ -21,6 +21,7 @@ import com.amplitude.android.Configuration
 import com.amplitude.android.events.BaseEvent
 import com.amplitude.android.events.EventOptions
 import com.amplitude.android.events.Plan
+import java.lang.reflect.Method
 
 enum class EventType(val value: String) {
     Identify("\$identify"),
@@ -507,6 +508,25 @@ open class Ampli {
 
         if (this.client?.configuration?.plan == null) {
             this.client?.configuration?.plan = defaultObservePlan
+        }
+
+        // set IngestionMetadata with backwards compatibility, min Android Kotlin SDK version 1.2.0.
+        try {
+            val clazz = Class.forName("com.amplitude.android.events.IngestionMetadata")
+            val clazzConstructor = clazz.getDeclaredConstructor(String::class.java, String::class.java)
+            val ingestionMetadata = clazzConstructor.newInstance("android-kotlin-ampli", "2.0.0")
+            val coreClazz = Class.forName("com.amplitude.core.events.IngestionMetadata")
+            val setIngestionMetadata: Method =
+                Configuration::class.java.getMethod("setIngestionMetadata", coreClazz)
+            setIngestionMetadata.invoke(this.client?.configuration, ingestionMetadata)
+        } catch (e: ClassNotFoundException) {
+            println("IngestionMetadata is available starting from Android Kotlin SDK 1.2.0 version")
+        } catch (e: NoSuchMethodException) {
+            println("IngestionMetadata is available starting from Android Kotlin SDK 1.2.0 version")
+        } catch (e: SecurityException) {
+            println("IngestionMetadata is available starting from Android Kotlin SDK 1.2.0 version")
+        } catch (e: Exception) {
+            System.err.println("Unexpected error when setting IngestionMetadata")
         }
     }
 

--- a/jre/java/AmpliApp/pom.xml
+++ b/jre/java/AmpliApp/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.amplitude</groupId>
             <artifactId>java-sdk</artifactId>
-            <version>1.8.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/jre/kotlin/AmpliApp/build.gradle
+++ b/jre/kotlin/AmpliApp/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amplitude:java-sdk:1.10.1'
+    implementation 'com.amplitude:java-sdk:1.10.1+'
     implementation 'org.json:json:20201115'
 
     implementation 'io.github.cdimascio:dotenv-kotlin:6.2.2'

--- a/jre/kotlin/AmpliApp/build.gradle
+++ b/jre/kotlin/AmpliApp/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amplitude:java-sdk:1.8.0'
+    implementation 'com.amplitude:java-sdk:1.10.1'
     implementation 'org.json:json:20201115'
 
     implementation 'io.github.cdimascio:dotenv-kotlin:6.2.2'

--- a/jre/kotlin/AmpliApp/build.gradle
+++ b/jre/kotlin/AmpliApp/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.amplitude:java-sdk:1.10.1+'
+    implementation 'com.amplitude:java-sdk:1.+'
     implementation 'org.json:json:20201115'
 
     implementation 'io.github.cdimascio:dotenv-kotlin:6.2.2'

--- a/jre/kotlin/AmpliApp/src/main/kotlin/com/amplitude/ampli/Ampli.kt
+++ b/jre/kotlin/AmpliApp/src/main/kotlin/com/amplitude/ampli/Ampli.kt
@@ -16,12 +16,13 @@
 
 package com.amplitude.ampli
 
-import com.amplitude.Amplitude
-import com.amplitude.MiddlewareExtra
-import com.amplitude.Plan
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+
+import com.amplitude.Amplitude
+import com.amplitude.MiddlewareExtra
+import com.amplitude.Plan
 
 abstract class Event<E: Event<E>>(
     val eventType: String,


### PR DESCRIPTION
## Notes
This change adds the ingestionMetadata to event with the backwards compatibility support.

This example uses Java reflection, which is working for both old version and new version Java/Kotlin SDKs, including:
- jre-java v1
- jre-kotlin v1
- android-java v1
- android-java v2
- android-kotlin v1
- android-kotlin v2

## Updates
- feat: update ingestion metadata jre examples

## Tests
- echo server with both old/new version Java SDKs