### PR TITLE
feat: add ingestion metadata to go ampli example

### DIFF
--- a/go/simple/v2/ampli/ampli.go
+++ b/go/simple/v2/ampli/ampli.go
@@ -1208,6 +1208,13 @@ func (a *Ampli) Load(options LoadOptions) {
 		}
 	}
 
+	if clientConfig.IngestionMetadata == nil {
+		clientConfig.IngestionMetadata = &amplitude.IngestionMetadata{
+			SourceName:    `go-go-ampli`,
+			SourceVersion: `2.0.0`,
+		}
+	}
+
 	if options.Client.Instance != nil {
 		a.Client = options.Client.Instance
 	} else {


### PR DESCRIPTION
## Notes
This PR adds ingestion metadata to go ampli example.

## Updates
- feat: add ingestion metadata to go ampli example

## Tests
- echo server with `ampli:local`