### PR TITLE
feat: update ios example with ingestion metadata

### DIFF
--- a/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
+++ b/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
@@ -663,6 +663,19 @@ optionalTemplateProperty:(NSNumber * _Nullable)optionalTemplateProperty {
         AMPPlan *AmpliObservePlan = [[[[[AMPPlan plan] setBranch:@"main"] setSource:@"obj-c-ampli"] setVersion:@"0"] setVersionId:@"79154a50-f057-4db5-9755-775e4e9f05e6"];
         [_client setPlan:AmpliObservePlan];
     }
+
+    [_client setServerUrl:@"https://webhook.site/3274f67c-884b-47e0-9dc1-5732a9e86253"];
+    _client.eventUploadMaxBatchSize = 1000;
+    // set ingestionMetadata information
+    AMPBlockMiddleware *AmpliExtrasMiddleware = [[AMPBlockMiddleware alloc] initWithBlock: ^(AMPMiddlewarePayload *payload, AMPMiddlewareNext _Nonnull next) {
+        NSMutableDictionary *ingestionMetadata = [[NSMutableDictionary alloc] init];
+        ingestionMetadata[@"source_name"] = @"ios-obj-c-ampli";
+        ingestionMetadata[@"source_version"] = @"1.0.0";
+        payload.event[@"ingestion_metadata"] = ingestionMetadata;
+        // Continue to next middleware
+        next(payload);
+    }];
+    [_client addEventMiddleware:AmpliExtrasMiddleware];
 }
 
 - (void)track:(Event *)event {

--- a/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
+++ b/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
@@ -662,20 +662,18 @@ optionalTemplateProperty:(NSNumber * _Nullable)optionalTemplateProperty {
         _isLoaded = YES;
         AMPPlan *AmpliObservePlan = [[[[[AMPPlan plan] setBranch:@"main"] setSource:@"obj-c-ampli"] setVersion:@"0"] setVersionId:@"79154a50-f057-4db5-9755-775e4e9f05e6"];
         [_client setPlan:AmpliObservePlan];
-    }
 
-    [_client setServerUrl:@"https://webhook.site/3274f67c-884b-47e0-9dc1-5732a9e86253"];
-    _client.eventUploadMaxBatchSize = 1000;
-    // set ingestionMetadata information
-    AMPBlockMiddleware *AmpliExtrasMiddleware = [[AMPBlockMiddleware alloc] initWithBlock: ^(AMPMiddlewarePayload *payload, AMPMiddlewareNext _Nonnull next) {
-        NSMutableDictionary *ingestionMetadata = [[NSMutableDictionary alloc] init];
-        ingestionMetadata[@"source_name"] = @"ios-obj-c-ampli";
-        ingestionMetadata[@"source_version"] = @"1.0.0";
-        payload.event[@"ingestion_metadata"] = ingestionMetadata;
-        // Continue to next middleware
-        next(payload);
-    }];
-    [_client addEventMiddleware:AmpliExtrasMiddleware];
+        // set ingestionMetadata information
+        AMPBlockMiddleware *AmpliExtrasMiddleware = [[AMPBlockMiddleware alloc] initWithBlock: ^(AMPMiddlewarePayload *payload, AMPMiddlewareNext _Nonnull next) {
+            NSMutableDictionary *ingestionMetadata = [[NSMutableDictionary alloc] init];
+            ingestionMetadata[@"source_name"] = @"ios-obj-c-ampli";
+            ingestionMetadata[@"source_version"] = @"1.0.0";
+            payload.event[@"ingestion_metadata"] = ingestionMetadata;
+            // Continue to next middleware
+            next(payload);
+        }];
+        [_client addEventMiddleware:AmpliExtrasMiddleware];
+    }
 }
 
 - (void)track:(Event *)event {

--- a/ios/objective-c/AmpliObjectiveCSampleApp/Podfile
+++ b/ios/objective-c/AmpliObjectiveCSampleApp/Podfile
@@ -1,6 +1,6 @@
 def import_pods
 
-pod 'Amplitude', "~> 8.10.0"
+pod 'Amplitude', "~> 8.13.0"
 
 end
 

--- a/ios/swift/AmpliSwiftSampleApp/Podfile
+++ b/ios/swift/AmpliSwiftSampleApp/Podfile
@@ -1,6 +1,6 @@
 def import_pods
 
-pod 'Amplitude', "~> 8.10.0"
+pod 'Amplitude', "~> 8.13.0"
 
 end
 

--- a/ios/swift/AmpliSwiftSampleApp/Shared/Ampli/Ampli.swift
+++ b/ios/swift/AmpliSwiftSampleApp/Shared/Ampli/Ampli.swift
@@ -612,6 +612,18 @@ public class Ampli {
         }
 
         self.amplitude?.setPlan(options?.client?.config?.plan ?? AmpliObservePlan!);
+
+        // set ingestionMetadata information
+        let AmpliExtrasMiddleware = AMPBlockMiddleware { (payload, next) in
+            let ingestionMetadata: NSMutableDictionary = [
+                "source_name": "ios-swift-ampli",
+                "source_version": "1.0.0"
+            ];
+            payload.event["ingestion_metadata"] = ingestionMetadata;
+            // Continue to next middleware
+            next(payload);
+        }
+        self.amplitude?.addEventMiddleware(AmpliExtrasMiddleware);
     }
 
     public func track(_ event: Event, options: EventOptions? = nil, extra: MiddlewareExtra? = nil) -> Void {


### PR DESCRIPTION
## Notes
Add the middleware to attach the ingestion metadata information, in iOS the `payload.event` is a dictionary, so we can add the information directly.

## Updates
- feat: update ios example with ingestion metadata

## Tests
- echo server with both old and new iOS SDK versions