### PR TITLE
AMP-64549 update python examples after mutliple environments changes

### DIFF
--- a/python/django/v1/ampli_app/ampli/ampli.py
+++ b/python/django/v1/ampli_app/ampli/ampli.py
@@ -28,13 +28,13 @@ from amplitude import Amplitude, Config, Plan, BaseEvent, EventOptions, Identify
 
 
 class Environment(enum.Enum):
-    DEVELOPMENT = 'development'
-    PRODUCTION = 'production'
+    DEV = 'dev'
+    PROD = 'prod'
 
 
 API_KEY: Dict[Environment, str] = {
-    Environment("development"): "",
-    Environment("production"): ""
+    Environment("dev"): "",
+    Environment("prod"): ""
 }
 
 DEFAULT_CONFIGURATION = Config(
@@ -478,13 +478,12 @@ class Ampli:
         self.client: Amplitude = None
         self.disabled: bool = False
 
-    def load(self, options: Optional[LoadOptions] = None):
+    def load(self, options: LoadOptions):
         """Initialize the Ampli wrapper. Call once when your application starts.
 
-        :param options: Configuration options to initialize the Ampli wrapper with.
+        :param options: Configuration options to initialize the Ampli wrapper with. 'environment', 'client.api_key' or 'client.instance' is required.
         """
-        if not options:
-            options = LoadOptions()
+
         self.disabled = options.disabled
 
         if self.client:

--- a/python/django/v1/ampli_app/tests.py
+++ b/python/django/v1/ampli_app/tests.py
@@ -29,7 +29,7 @@ class AmpliDjangoTestCase(TestCase):
         ampli.load(LoadOptions(client=LoadClientOptions(api_key="TEST_API_KEY")))
         self.assertTrue(ampli.initialized_and_enabled())
         with self.assertLogs(None, 'WARN') as cm:
-            ampli.load()
+            ampli.load(LoadOptions(client=LoadClientOptions(api_key="TEST_API_KEY")))
             self.assertEqual([
                 'WARNING:ampli_app.ampli.ampli:Warning: Ampli is already initialized. ampli.load() should be called once at application start up.'],
                 cm.output)

--- a/python/simple/v1/ampli/ampli.py
+++ b/python/simple/v1/ampli/ampli.py
@@ -28,13 +28,13 @@ from amplitude import Amplitude, Config, Plan, BaseEvent, EventOptions, Identify
 
 
 class Environment(enum.Enum):
-    DEVELOPMENT = 'development'
-    PRODUCTION = 'production'
+    DEV = 'dev'
+    PROD = 'prod'
 
 
 API_KEY: Dict[Environment, str] = {
-    Environment("development"): "",
-    Environment("production"): ""
+    Environment("dev"): "",
+    Environment("prod"): ""
 }
 
 DEFAULT_CONFIGURATION = Config(
@@ -478,13 +478,12 @@ class Ampli:
         self.client: Amplitude = None
         self.disabled: bool = False
 
-    def load(self, options: Optional[LoadOptions] = None):
+    def load(self, options: LoadOptions):
         """Initialize the Ampli wrapper. Call once when your application starts.
 
-        :param options: Configuration options to initialize the Ampli wrapper with.
+        :param options: Configuration options to initialize the Ampli wrapper with. 'environment', 'client.api_key' or 'client.instance' is required.
         """
-        if not options:
-            options = LoadOptions()
+
         self.disabled = options.disabled
 
         if self.client:

--- a/python/simple/v1/ampli/requirements.txt
+++ b/python/simple/v1/ampli/requirements.txt
@@ -23,4 +23,4 @@
 # (not inside this directory)
 # Add '-r ampli/requirements.txt' to your ~/my/project/requirements.txt
 
-amplitude-analytics >= 1.1.0
+amplitude-analytics

--- a/python/simple/v1/app.py
+++ b/python/simple/v1/app.py
@@ -8,7 +8,7 @@ api_key = envs['AMPLITUDE_API_KEY']
 write_key = envs['SEGMENT_WRITE_KEY']
 
 # Initialize the Ampli instance with LoadOptions and LoadClientOptions
-ampli.load(LoadOptions(Environment.DEVELOPMENT, False,
+ampli.load(LoadOptions(Environment.DEV, False,
                        client=LoadClientOptions(api_key=api_key, configuration=Config(server_zone='EU'))))
 
 # Identify using IdentifyProperties in tracking plan

--- a/python/simple/v1/test_ampli.py
+++ b/python/simple/v1/test_ampli.py
@@ -33,7 +33,7 @@ class AmpliPythonTestCase(unittest.TestCase):
         ampli.load(LoadOptions(client=LoadClientOptions(api_key="TEST_API_KEY")))
         self.assertTrue(ampli.initialized_and_enabled())
         with self.assertLogs(None, 'WARN') as cm:
-            ampli.load()
+            ampli.load(LoadOptions(client=LoadClientOptions(api_key="TEST_API_KEY")))
             self.assertEqual([
                 'WARNING:ampli.ampli:Warning: Ampli is already initialized. ampli.load() should be called once at application start up.'],
                 cm.output)


### PR DESCRIPTION
Re-run `ampli pull`, fix tests for `python`