### PR TITLE
AMP-64549 go changes after mutliple environments codegen changes

### DIFF
--- a/go/simple/v2/ampli/ampli.go
+++ b/go/simple/v2/ampli/ampli.go
@@ -47,15 +47,15 @@ var Instance = Ampli{}
 type Environment string
 
 const (
-	EnvironmentDevelopment Environment = `development`
+	EnvironmentDev Environment = `dev`
 
-	EnvironmentProduction Environment = `production`
+	EnvironmentProd Environment = `prod`
 )
 
 var APIKey = map[Environment]string{
-	EnvironmentDevelopment: ``,
+	EnvironmentDev: ``,
 
-	EnvironmentProduction: ``,
+	EnvironmentProd: ``,
 }
 
 // LoadClientOptions is Client options setting to initialize Ampli client.

--- a/go/simple/v2/tests/ampli_test.go
+++ b/go/simple/v2/tests/ampli_test.go
@@ -137,9 +137,9 @@ func (t *AmpliSuite) TestShutdown() {
 
 func (t *AmpliSuite) TestLoadWithEnvironment() {
 	instance := ampli.Ampli{}
-	ampli.APIKey[ampli.EnvironmentDevelopment] = "test-development-api-key"
+	ampli.APIKey[ampli.EnvironmentDev] = "test-development-api-key"
 	instance.Load(ampli.LoadOptions{
-		Environment: ampli.EnvironmentDevelopment,
+		Environment: ampli.EnvironmentDev,
 	})
 
 	t.Assert().Equal("test-development-api-key", instance.Client.Config().APIKey)


### PR DESCRIPTION
Re-run `ampli pull`, fix tests for `go`