### PR TITLE
DXOC-831 Updated codegen with '$identify' event type

### DIFF
--- a/android/java/v1/AmpliApp/app/src/main/java/com/amplitude/ampli/Identify.java
+++ b/android/java/v1/AmpliApp/app/src/main/java/com/amplitude/ampli/Identify.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 
 public class Identify extends Event {
     private Identify(Builder builder) {
-        super("$identify", builder.properties);
+        super(com.amplitude.api.Constants.IDENTIFY_EVENT, builder.properties);
     }
 
     public static IRequiredNumber builder() { return new Builder(); }

--- a/android/java/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Identify.java
+++ b/android/java/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Identify.java
@@ -20,7 +20,7 @@ import com.amplitude.android.events.BaseEvent;
 
 public class Identify extends BaseEvent {
     private Identify(Builder builder) {
-        eventType = "$identify";
+        eventType = com.amplitude.core.Constants.IDENTIFY_EVENT;
         setEventProperties(builder.properties);
     }
 

--- a/android/kotlin/v1/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
+++ b/android/kotlin/v1/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
@@ -22,6 +22,7 @@ import org.json.JSONObject
 
 import com.amplitude.api.Amplitude
 import com.amplitude.api.AmplitudeClient
+import com.amplitude.api.Constants
 import com.amplitude.api.MiddlewareExtra
 import com.amplitude.api.Plan
 
@@ -63,7 +64,7 @@ class LoadClientOptions(
 class Identify private constructor(
     eventProperties: Map<String, Any?>?,
     options: EventOptions? = null
-) : Event<Identify>("Identify", eventProperties, options, ::Identify) {
+) : Event<Identify>(Constants.IDENTIFY_EVENT, eventProperties, options, ::Identify) {
     /**
      * Identify
      *

--- a/android/kotlin/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
+++ b/android/kotlin/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
@@ -21,11 +21,12 @@ import com.amplitude.android.Configuration
 import com.amplitude.android.events.BaseEvent
 import com.amplitude.android.events.EventOptions
 import com.amplitude.android.events.Plan
+import com.amplitude.core.Constants
 import com.amplitude.core.platform.Plugin
 
 enum class EventType(val value: String) {
-    Identify("\$identify"),
-    GroupIdentify("\$groupidentify"),
+    Identify(Constants.IDENTIFY_EVENT),
+    GroupIdentify(Constants.GROUP_IDENTIFY_EVENT),
 }
 
 class LoadOptions(

--- a/browser/javascript/v1/react-app/src/ampli/index.js
+++ b/browser/javascript/v1/react-app/src/ampli/index.js
@@ -120,8 +120,8 @@ export const ApiKey = {
  */
 
 export const SpecialEventType = {
-  Identify: "Identify",
-  Group: "Group"
+  Identify: "$identify",
+  Group: "$groupidentify"
 }
 
 /**
@@ -144,7 +144,7 @@ export const DefaultOptions = {
 
 export class Identify {
   constructor(properties) {
-    this.event_type = 'Identify';
+    this.event_type = SpecialEventType.Identify;
     this.event_properties = properties;
   }
 }

--- a/browser/javascript/v2/ember-app/app/ampli/index.js
+++ b/browser/javascript/v2/ember-app/app/ampli/index.js
@@ -98,7 +98,7 @@ export const DefaultConfiguration = {
 
 export class Identify {
   constructor(properties) {
-    this.event_type = 'Identify';
+    this.event_type = amplitude.Types.SpecialEventType.IDENTIFY;
     this.event_properties = properties;
   }
 }

--- a/browser/javascript/v2/react-app/src/ampli/index.js
+++ b/browser/javascript/v2/react-app/src/ampli/index.js
@@ -98,7 +98,7 @@ export const DefaultConfiguration = {
 
 export class Identify {
   constructor(properties) {
-    this.event_type = 'Identify';
+    this.event_type = amplitude.Types.SpecialEventType.IDENTIFY;
     this.event_properties = properties;
   }
 }

--- a/browser/typescript/v1/react-app/src/ampli/index.ts
+++ b/browser/typescript/v1/react-app/src/ampli/index.ts
@@ -376,7 +376,7 @@ export interface SourceTemplateProperties {
 }
 
 export class Identify implements BaseEvent {
-  event_type = 'Identify';
+  event_type = SpecialEventType.Identify;
 
   constructor(
     public event_properties: IdentifyProperties,
@@ -906,8 +906,8 @@ export type Plan = {
 }
 
 export enum SpecialEventType {
-  Identify = "Identify",
-  Group = "Group"
+  Identify = "$identify",
+  Group = "$groupidentify"
 }
 
 export type BaseEvent = {

--- a/browser/typescript/v2/react-app/src/ampli/index.ts
+++ b/browser/typescript/v2/react-app/src/ampli/index.ts
@@ -376,7 +376,7 @@ export interface SourceTemplateProperties {
 }
 
 export class Identify implements BaseEvent {
-  event_type = 'Identify';
+  event_type = amplitude.Types.SpecialEventType.IDENTIFY;
 
   constructor(
     public event_properties: IdentifyProperties,

--- a/go/simple/v2/ampli/ampli.go
+++ b/go/simple/v2/ampli/ampli.go
@@ -154,7 +154,7 @@ func (b *identifyBuilder) OptionalArray(optionalArray []string) IdentifyBuilder 
 
 func (b *identifyBuilder) Build() IdentifyEvent {
 	return &identifyEvent{
-		newBaseEvent(`Identify`, b.properties),
+		newBaseEvent(IdentifyEventType, b.properties),
 	}
 }
 

--- a/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
+++ b/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
@@ -18,6 +18,7 @@
 #import "Ampli.h"
 #import "Amplitude.h"
 #import "AMPPlan.h"
+#import "AMPConstants.h"
 
 @implementation Event: NSObject
 

--- a/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
+++ b/ios/objective-c/AmpliObjectiveCSampleApp/AmpliObjectiveCSampleApp/Ampli/Ampli.m
@@ -67,7 +67,7 @@
 
 - (instancetype)initWithRequiredNumber_Identify:(Float64)requiredNumber
 optionalArray:(NSArray<NSString *> * _Nullable)optionalArray {
-    self = [super initWithEventType:@"Identify"
+    self = [super initWithEventType:IDENTIFY_EVENT
                     withEventProperties:@{
                         @"optionalArray": optionalArray ?: NSNull.null,
                         @"requiredNumber": @(requiredNumber)

--- a/ios/swift/AmpliSwiftSampleApp/Shared/Ampli/Ampli.swift
+++ b/ios/swift/AmpliSwiftSampleApp/Shared/Ampli/Ampli.swift
@@ -67,7 +67,7 @@ public class Identify : GenericEvent<Identify> {
 
     private init(_ eventProperties: [String: Any?]?, _ options: EventOptions? = nil) {
         super.init(
-            eventType: "Identify",
+            eventType: Constants.IDENTIFY_EVENT,
             eventProperties: eventProperties,
             options: options,
             eventFactory: Identify.init

--- a/ios/swift/AmpliSwiftSampleApp/Shared/Ampli/Ampli.swift
+++ b/ios/swift/AmpliSwiftSampleApp/Shared/Ampli/Ampli.swift
@@ -67,7 +67,7 @@ public class Identify : GenericEvent<Identify> {
 
     private init(_ eventProperties: [String: Any?]?, _ options: EventOptions? = nil) {
         super.init(
-            eventType: Constants.IDENTIFY_EVENT,
+            eventType: "$identify",
             eventProperties: eventProperties,
             options: options,
             eventFactory: Identify.init

--- a/jre/kotlin/AmpliApp/src/main/kotlin/com/amplitude/ampli/Ampli.kt
+++ b/jre/kotlin/AmpliApp/src/main/kotlin/com/amplitude/ampli/Ampli.kt
@@ -63,7 +63,7 @@ class LoadClientOptions(
 class Identify private constructor(
     eventProperties: Map<String, Any?>?,
     options: EventOptions? = null
-) : Event<Identify>("Identify", eventProperties, options, ::Identify) {
+) : Event<Identify>("\$identify", eventProperties, options, ::Identify) {
     /**
      * Identify
      *

--- a/jre/kotlin/AmpliApp/src/test/kotlin/AmpliTest.kt
+++ b/jre/kotlin/AmpliApp/src/test/kotlin/AmpliTest.kt
@@ -62,7 +62,7 @@ class AmpliTest {
         verify(client, times(1)).logEvent(eventCaptor.capture(), extraCaptor.capture())
 
         val event = eventCaptor.value
-        assertEquals("Identify", event.eventType)
+        assertEquals("\$identify", event.eventType)
         assertEquals(userId, event.userId)
         assertEquals(deviceId, event.deviceId)
         assertEquals(

--- a/node/javascript/v1/AmpliApp/package.json
+++ b/node/javascript/v1/AmpliApp/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@amplitude/identify": "1.10.0",
     "@amplitude/node": "1.10.2",
+    "@amplitude/types": "1.10.2",
     "@itly/plugin-segment-node": "^2.3.4",
     "@itly/sdk": "^2.3.4",
     "@types/analytics-node": "^3.1.6",

--- a/node/javascript/v1/AmpliApp/src/ampli/index.js
+++ b/node/javascript/v1/AmpliApp/src/ampli/index.js
@@ -18,6 +18,7 @@
 
 const { Identify: AmplitudeIdentify, IdentifyEvent } = require('@amplitude/identify');
 const { init: initNodeClient, NodeClient, Status, Options } = require('@amplitude/node');
+const { SpecialEventType } = require('@amplitude/types');
 
 /**
  * @typedef {Object} BaseEvent
@@ -104,7 +105,7 @@ const DefaultOptions = {
 
 class Identify {
   constructor(properties) {
-    this.event_type = 'Identify';
+    this.event_type = SpecialEventType.IDENTIFY;
     this.event_properties = properties;
   }
 }

--- a/node/javascript/v1/AmpliApp/yarn.lock
+++ b/node/javascript/v1/AmpliApp/yarn.lock
@@ -30,15 +30,15 @@
     "@amplitude/utils" "^1.10.2"
     tslib "^2.0.0"
 
+"@amplitude/types@1.10.2", "@amplitude/types@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.10.2.tgz#8f3c6c3c9ee24f401ee037b351c3c67eb945eefc"
+  integrity sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg==
+
 "@amplitude/types@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.10.0.tgz#dfaf7cc25f533a1e2b0ef0ad675371b396733c0f"
   integrity sha512-xN0gnhutztv6kqHaZ2bre18anQV5GDmMXOeipTvI670g2VjNbPfOzMwu1LN4p1NadYq+GqYI223UcZrXR+R4Pw==
-
-"@amplitude/types@^1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@amplitude/types/-/types-1.10.2.tgz#8f3c6c3c9ee24f401ee037b351c3c67eb945eefc"
-  integrity sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg==
 
 "@amplitude/utils@^1.10.0":
   version "1.10.0"

--- a/node/javascript/v2/AmpliApp/src/ampli/index.js
+++ b/node/javascript/v2/AmpliApp/src/ampli/index.js
@@ -98,7 +98,7 @@ const DefaultConfiguration = {
 
 class Identify {
   constructor(properties) {
-    this.event_type = 'Identify';
+    this.event_type = amplitude.Types.SpecialEventType.IDENTIFY;
     this.event_properties = properties;
   }
 }

--- a/node/nextjs/ampli-app/lib/ampli/index.ts
+++ b/node/nextjs/ampli-app/lib/ampli/index.ts
@@ -19,7 +19,7 @@
 import { Identify as AmplitudeIdentify } from '@amplitude/identify';
 import { init as initNodeClient, NodeClient, Response, Status } from '@amplitude/node';
 import {
-  BaseEvent, Event, EventOptions, GroupOptions, IdentifyEvent, IdentifyOptions, Options, MiddlewareExtra,
+  BaseEvent, Event, EventOptions, GroupOptions, IdentifyEvent, IdentifyOptions, Options, MiddlewareExtra, SpecialEventType,
 } from '@amplitude/types';
 
 export type Environment = 'prod' | 'dev';
@@ -380,7 +380,7 @@ export interface SourceTemplateProperties {
 }
 
 export class Identify implements BaseEvent {
-  event_type = 'Identify';
+  event_type = SpecialEventType.IDENTIFY;
 
   constructor(
     public event_properties: IdentifyProperties,

--- a/node/typescript/v1/AmpliApp/src/ampli/index.ts
+++ b/node/typescript/v1/AmpliApp/src/ampli/index.ts
@@ -19,7 +19,7 @@
 import { Identify as AmplitudeIdentify } from '@amplitude/identify';
 import { init as initNodeClient, NodeClient, Response, Status } from '@amplitude/node';
 import {
-  BaseEvent, Event, EventOptions, GroupOptions, IdentifyEvent, IdentifyOptions, Options, MiddlewareExtra,
+  BaseEvent, Event, EventOptions, GroupOptions, IdentifyEvent, IdentifyOptions, Options, MiddlewareExtra, SpecialEventType,
 } from '@amplitude/types';
 
 export type Environment = 'prod' | 'dev';
@@ -380,7 +380,7 @@ export interface SourceTemplateProperties {
 }
 
 export class Identify implements BaseEvent {
-  event_type = 'Identify';
+  event_type = SpecialEventType.IDENTIFY;
 
   constructor(
     public event_properties: IdentifyProperties,

--- a/node/typescript/v2/AmpliApp/src/ampli/index.ts
+++ b/node/typescript/v2/AmpliApp/src/ampli/index.ts
@@ -383,7 +383,7 @@ export interface SourceTemplateProperties {
 }
 
 export class Identify implements BaseEvent {
-  event_type = 'Identify';
+  event_type = amplitude.Types.SpecialEventType.IDENTIFY;
 
   constructor(
     public event_properties: IdentifyProperties,

--- a/react-native/javascript/v1/AmpliApp/src/ampli/index.js
+++ b/react-native/javascript/v1/AmpliApp/src/ampli/index.js
@@ -22,6 +22,7 @@ import {
   Identify as AmplitudeIdentify,
   MiddlewareExtra,
   Plan,
+  SpecialEventType,
 } from '@amplitude/react-native';
 
 /**
@@ -97,7 +98,7 @@ export const DefaultOptions = {
 
 export class Identify {
   constructor(properties) {
-    this.eventType = 'Identify';
+    this.eventType = SpecialEventType.IDENTIFY;
     this.eventProperties = properties;
   }
 }

--- a/react-native/javascript/v2/AmpliApp/src/ampli/index.js
+++ b/react-native/javascript/v2/AmpliApp/src/ampli/index.js
@@ -97,7 +97,7 @@ export const DefaultConfiguration = {
 
 export class Identify {
   constructor(properties) {
-    this.event_type = 'Identify';
+    this.event_type = amplitude.Types.SpecialEventType.IDENTIFY;
     this.event_properties = properties;
   }
 }

--- a/react-native/typescript/v1/AmpliApp/src/ampli/index.ts
+++ b/react-native/typescript/v1/AmpliApp/src/ampli/index.ts
@@ -23,6 +23,7 @@ import {
   BaseEvent as Event,
   MiddlewareExtra,
   Plan,
+  SpecialEventType,
 } from '@amplitude/react-native';
 
 export type EventOptions = {
@@ -389,7 +390,7 @@ export interface SourceTemplateProperties {
 }
 
 export class Identify implements Event {
-  eventType = 'Identify';
+  eventType = SpecialEventType.IDENTIFY;
 
   constructor(
     public eventProperties: IdentifyProperties,

--- a/react-native/typescript/v2/AmpliApp/src/ampli/index.ts
+++ b/react-native/typescript/v2/AmpliApp/src/ampli/index.ts
@@ -384,7 +384,7 @@ export interface SourceTemplateProperties {
 }
 
 export class Identify implements BaseEvent {
-  event_type = 'Identify';
+  event_type = amplitude.Types.SpecialEventType.IDENTIFY;
 
   constructor(
     public event_properties: IdentifyProperties,


### PR DESCRIPTION
Switched to `$identify` event type for Identify event (SDK constants if available)

Swift tests hang for some reason in CI (XCode 13.1, iPhone 11, OS=15.0) - locally they work fine (XCode 14.2, iPhone 14, OS=16.2).