### PR TITLE
feat: pin all GitHub Actions and Docker images to SHA

### DIFF
--- a/.github/workflows/ampli-merge-check.android-v1.yml
+++ b/.github/workflows/ampli-merge-check.android-v1.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Android Kotlin V1) Check the Data branch is merged before merging the Git branch
         working-directory: ./android/kotlin/v1/AmpliApp

--- a/.github/workflows/ampli-merge-check.android-v2.yml
+++ b/.github/workflows/ampli-merge-check.android-v2.yml
@@ -9,14 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Android Kotlin V2) Check the Data branch is merged before merging the Git branch
         working-directory: ./android/kotlin/v2/AmpliApp

--- a/.github/workflows/ampli-merge-check.browser-v1.yml
+++ b/.github/workflows/ampli-merge-check.browser-v1.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Browser JS V1) Check the Data branch is merged before merging the Git branch
         working-directory: ./browser/javascript/v1/react-app

--- a/.github/workflows/ampli-merge-check.browser-v2.yml
+++ b/.github/workflows/ampli-merge-check.browser-v2.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Browser JS V2) Check the Data branch is merged before merging the Git branch
         working-directory: ./browser/javascript/v2/react-app

--- a/.github/workflows/ampli-merge-check.go.yml
+++ b/.github/workflows/ampli-merge-check.go.yml
@@ -9,14 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Go) Check the Data branch is merged before merging the Git branch
         working-directory: go/simple/v2

--- a/.github/workflows/ampli-merge-check.ios.yml
+++ b/.github/workflows/ampli-merge-check.ios.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli-swift
+      image: amplitudeinc/ampli-swift@sha256:187036956d9b9906f0e525f9c438ced2f22fa7b968ec4e78146d76949a4385be
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (iOS Swift V1) Check the Data branch is merged before merging the Git branch
         working-directory: ./ios/swift/v1/AmpliSwiftSampleApp

--- a/.github/workflows/ampli-merge-check.jre.yml
+++ b/.github/workflows/ampli-merge-check.jre.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     timeout-minutes: 2
 
     env:
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (JRE Kotlin) Check the Data branch is merged before merging the Git branch
         working-directory: ./jre/kotlin/AmpliApp

--- a/.github/workflows/ampli-merge-check.node-v1.yml
+++ b/.github/workflows/ampli-merge-check.node-v1.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Node JS V1) Check the Data branch is merged before merging the Git branch
         working-directory: ./node/javascript/v1/AmpliApp

--- a/.github/workflows/ampli-merge-check.node-v2.yml
+++ b/.github/workflows/ampli-merge-check.node-v2.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Node JS V2) Check the Data branch is merged before merging the Git branch
         working-directory: ./node/javascript/v2/AmpliApp

--- a/.github/workflows/ampli-merge-check.python.yml
+++ b/.github/workflows/ampli-merge-check.python.yml
@@ -9,14 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (Python) Check the Data branch is merged before merging the Git branch
         working-directory: python/simple/v1

--- a/.github/workflows/ampli-merge-check.react-native-v1.yml
+++ b/.github/workflows/ampli-merge-check.react-native-v1.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (ReactNative JS V1) Check the Data branch is merged before merging the Git branch
         working-directory: ./react-native/javascript/v1/AmpliApp

--- a/.github/workflows/ampli-merge-check.react-native-v2.yml
+++ b/.github/workflows/ampli-merge-check.react-native-v2.yml
@@ -10,14 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: amplitudeinc/ampli
+      image: amplitudeinc/ampli@sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9
     env:
       API_URL: https://data-api.staging.amplitude.com/graphql
       APP_URL: https://data.staging.amplitude.com/
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: (ReactNative JS V2) Check the Data branch is merged before merging the Git branch
         working-directory: ./react-native/javascript/v2/AmpliApp

--- a/.github/workflows/ci-build-android-test.yml
+++ b/.github/workflows/ci-build-android-test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set Java SDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
         with:
           distribution: 'zulu'
           java-version: '11'

--- a/.github/workflows/ci-build-ember-js-v2-test.yml
+++ b/.github/workflows/ci-build-ember-js-v2-test.yml
@@ -13,10 +13,10 @@ jobs:
         node-version: [ 14.x ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/ci-build-go-test.yml
+++ b/.github/workflows/ci-build-go-test.yml
@@ -14,10 +14,10 @@ jobs:
         go: [ '1.17', '1.18', '1.19' ]
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/ci-build-ios-v1-test.yml
+++ b/.github/workflows/ci-build-ios-v1-test.yml
@@ -15,20 +15,20 @@ jobs:
         ruby-version: ["2.7.x"]
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set Xcode 14.2
         run: |
           sudo xcode-select -switch /Applications/Xcode_14.2.app
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: actions/setup-ruby@b007fae6f1ffbe3a51c00a6df6f5ff01184d5340 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
       - name: Cache Bundle Gems and Cocoapods For Swift
         id: cache-gems-pods
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: |
             ./ios/swift/v1/AmpliSwiftSampleApp/Pods
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache Bundle Gems and Cocoapods For Objective-C
         id: cache-gems-objc-pods
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: |
             ./ios/objective-c/v1/AmpliObjectiveCSampleApp/Pods

--- a/.github/workflows/ci-build-ios-v2-test.yml
+++ b/.github/workflows/ci-build-ios-v2-test.yml
@@ -15,7 +15,7 @@ jobs:
         ruby-version: ["2.7.x"]
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set Xcode 14.2
         run: |

--- a/.github/workflows/ci-build-jre-test.yml
+++ b/.github/workflows/ci-build-jre-test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set Java SDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
         with:
           distribution: 'zulu'
           java-version: '8'

--- a/.github/workflows/ci-build-js-ts-v1-test.yml
+++ b/.github/workflows/ci-build-js-ts-v1-test.yml
@@ -18,10 +18,10 @@ jobs:
       REACT_APP_AMPLITUDE_API_KEY: 'ampli-examples-test-api-key'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/ci-build-js-ts-v2-test.yml
+++ b/.github/workflows/ci-build-js-ts-v2-test.yml
@@ -18,10 +18,10 @@ jobs:
       REACT_APP_AMPLITUDE_API_KEY: 'ampli-examples-test-api-key'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/ci-build-python-test.yml
+++ b/.github/workflows/ci-build-python-test.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Set up Python 3.6
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.6"
 

--- a/.github/workflows/ci-build-react-native-test-v1.yml
+++ b/.github/workflows/ci-build-react-native-test-v1.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [ 14.x ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/ci-build-react-native-test-v2.yml
+++ b/.github/workflows/ci-build-react-native-test-v2.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [ 14.x ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@main
+    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@385c4ded2b2622fde1ac0930495805e11353d55f # main
     with:
       label: "ampli"
       subcomponent: "dx_ampli"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR pins all GitHub Actions and Docker images to SHA hashes for improved supply chain security.

## Changes

### GitHub Actions pinned to SHA (10 total):
| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v2 | `ee0669bd1cc54295c223e0bb666b733df41de1c5` |
| `actions/checkout` | v3 | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/setup-ruby` | v1 | `b007fae6f1ffbe3a51c00a6df6f5ff01184d5340` |
| `actions/cache` | v2 | `8492260343ad570701412c2f464a5877dc76bace` |
| `actions/setup-java` | v2 | `91d3aa4956ec4a53e477c4907347b5e3481be8c9` |
| `actions/setup-node` | v2 | `7c12f8017d5436eb855f1ed4399f037a36fbd9e8` |
| `actions/setup-node` | v3 | `3235b876344d2a9aa001b8d1453c930bba69e610` |
| `actions/setup-go` | v3 | `be3c94b385c4f180051c996d336f57a34c397495` |
| `actions/setup-python` | v3 | `3542bca2639a428e1796aaa6a2ffef0c0f575566` |
| `amplitude/Amplitude-TypeScript` (reusable workflow) | main | `385c4ded2b2622fde1ac0930495805e11353d55f` |

### Container images pinned to SHA digest (2 total):
| Image | SHA Digest |
|-------|------------|
| `amplitudeinc/ampli` | `sha256:99d093218ddcc96ea4eaf42997612af30d6337a6d0d0c21aa6292a9cfe5fc0d9` |
| `amplitudeinc/ampli-swift` | `sha256:187036956d9b9906f0e525f9c438ced2f22fa7b968ec4e78146d76949a4385be` |

### Files modified (24 workflow files):
- All `ampli-merge-check.*.yml` files (12 files)
- All `ci-build-*.yml` files (11 files)
- `jira-issue-create.yml`

## Why

Pinning actions and images to SHA hashes instead of tags provides better supply chain security by:
- Ensuring reproducible builds with immutable references
- Preventing supply chain attacks where malicious code could be injected into mutable tags
- Meeting security compliance requirements for dependency pinning
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://amplitude.slack.com/archives/D092MJF4NKF/p1775084407266639?thread_ts=1775084407.266639&cid=D092MJF4NKF)

<div><a href="https://cursor.com/agents/bc-2f61d20b-3fa5-5c85-9095-053985995b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f61d20b-3fa5-5c85-9095-053985995b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

