### PR TITLE
fix: suppress deprecation warning in generated Ampli wrapper

### DIFF
--- a/.github/workflows/ci-build-android-test.yml
+++ b/.github/workflows/ci-build-android-test.yml
@@ -9,8 +9,8 @@ on:
       - 'android/java/v2/**'
 
 jobs:
-  test:
-    name: Test Android Kotlin/Java
+  test-v1:
+    name: Test Android V1 (JDK 11)
     runs-on: ubuntu-latest
 
     steps:
@@ -33,16 +33,6 @@ jobs:
         run: |
           ./gradlew --stop
 
-      - name: Run Kotlin V2 Tests
-        working-directory: ./android/kotlin/v2/AmpliApp
-        run: |
-          ./gradlew build
-
-      - name: Stop gradlew daemon for Kotlin V2
-        working-directory: ./android/kotlin/v2/AmpliApp
-        run: |
-          ./gradlew --stop
-
       - name: Run Java V1 Tests
         working-directory: ./android/java/v1/AmpliApp
         run: |
@@ -50,6 +40,30 @@ jobs:
 
       - name: Stop gradlew daemon for Java V1
         working-directory: ./android/java/v1/AmpliApp
+        run: |
+          ./gradlew --stop
+
+  test-v2:
+    name: Test Android V2 (JDK 17)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+
+      - name: Set Java SDK
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Run Kotlin V2 Tests
+        working-directory: ./android/kotlin/v2/AmpliApp
+        run: |
+          ./gradlew build
+
+      - name: Stop gradlew daemon for Kotlin V2
+        working-directory: ./android/kotlin/v2/AmpliApp
         run: |
           ./gradlew --stop
 

--- a/android/java/v2/AmpliApp/app/build.gradle
+++ b/android/java/v2/AmpliApp/app/build.gradle
@@ -3,12 +3,13 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    namespace "com.example.ampliapp"
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.ampliapp"
         minSdk 21
-        targetSdk 31
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/android/java/v2/AmpliApp/app/src/main/AndroidManifest.xml
+++ b/android/java/v2/AmpliApp/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.ampliapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/android/java/v2/AmpliApp/build.gradle
+++ b/android/java/v2/AmpliApp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
+        classpath "com.android.tools.build:gradle:8.7.3"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/java/v2/AmpliApp/gradle.properties
+++ b/android/java/v2/AmpliApp/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false

--- a/android/java/v2/AmpliApp/gradle/wrapper/gradle-wrapper.properties
+++ b/android/java/v2/AmpliApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Dec 14 11:58:33 SAMT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/java/v2/AmpliApp/settings.gradle
+++ b/android/java/v2/AmpliApp/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 rootProject.name = "Ampli App"

--- a/android/kotlin/v2/AmpliApp/app/build.gradle
+++ b/android/kotlin/v2/AmpliApp/app/build.gradle
@@ -8,12 +8,13 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    namespace "com.example.ampliapp"
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.ampliapp"
         minSdk 21
-        targetSdk 31
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -27,11 +28,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/android/kotlin/v2/AmpliApp/app/src/main/AndroidManifest.xml
+++ b/android/kotlin/v2/AmpliApp/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.ampliapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/android/kotlin/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
+++ b/android/kotlin/v2/AmpliApp/app/src/main/java/com/amplitude/ampli/Ampli.kt
@@ -64,6 +64,7 @@ val defaultObservePlan = Plan("main", "kotlin-ampli-v2", "1", "a61c3908-ca4d-4c8
 class DefaultConfiguration(apiKey: String, context : android.content.Context) {
     val config : Configuration
     init {
+        @Suppress("DEPRECATION")
         config = Configuration(
             apiKey = apiKey,
             context = context.applicationContext,

--- a/android/kotlin/v2/AmpliApp/app/src/main/java/com/example/ampliapp/SegmentDestinationPlugin.kt
+++ b/android/kotlin/v2/AmpliApp/app/src/main/java/com/example/ampliapp/SegmentDestinationPlugin.kt
@@ -27,10 +27,8 @@ class SegmentDestinationPlugin(appContext: Context, writeKey: String) : Destinat
 
     override fun track(payload: BaseEvent): BaseEvent {
         val eventProperties =  Properties()
-        payload.eventProperties?.forEach { entry -> entry.value?.let {
-            eventProperties.put(entry.key,
-                it
-            )
+        payload.eventProperties?.forEach { (key, value) -> value?.let {
+            eventProperties.put(key, it)
         } }
 
         analytics?.track(payload.eventType, eventProperties)
@@ -39,10 +37,8 @@ class SegmentDestinationPlugin(appContext: Context, writeKey: String) : Destinat
 
     override fun identify(payload: IdentifyEvent): IdentifyEvent {
         val traits = Traits()
-        payload.userProperties?.forEach { entry -> entry.value?.let {
-            traits.put(entry.key,
-                it
-            )
+        payload.userProperties?.forEach { (key, value) -> value?.let {
+            traits.put(key, it)
         } }
 
         Analytics.with(context).identify(traits)
@@ -53,10 +49,8 @@ class SegmentDestinationPlugin(appContext: Context, writeKey: String) : Destinat
         val traits = Traits()
         val groupId: String? = payload.groups?.keys?.first()
 
-        payload.groupProperties?.forEach { entry -> entry.value?.let {
-            traits.put(entry.key,
-                it
-            )
+        payload.groupProperties?.forEach { (key, value) -> value?.let {
+            traits.put(key, it)
         } }
 
         if (groupId != null) {

--- a/android/kotlin/v2/AmpliApp/app/src/test/java/com/example/ampliapp/AmpliTest.kt
+++ b/android/kotlin/v2/AmpliApp/app/src/test/java/com/example/ampliapp/AmpliTest.kt
@@ -140,8 +140,8 @@ class AmpliTest {
 
         verify(client, times(1)).track(
             eventCaptor.capture(),
-            eq(null),
-            eq(null)
+            isNull(),
+            isNull()
         )
         assertEquals("Event No Properties", eventCaptor.allValues.first().eventType )
     }
@@ -167,7 +167,7 @@ class AmpliTest {
         verify(client, times(1)).track(
             eventCaptor.capture(),
             optionsCaptor.capture(),
-            eq(null)
+            isNull()
         )
 
         assertEquals("Event With All Properties", eventCaptor.allValues.first().eventType)

--- a/android/kotlin/v2/AmpliApp/build.gradle
+++ b/android/kotlin/v2/AmpliApp/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0"
+        classpath "com.android.tools.build:gradle:8.7.3"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21"
     }
 }
 

--- a/android/kotlin/v2/AmpliApp/gradle.properties
+++ b/android/kotlin/v2/AmpliApp/gradle.properties
@@ -16,6 +16,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/android/kotlin/v2/AmpliApp/gradle/wrapper/gradle-wrapper.properties
+++ b/android/kotlin/v2/AmpliApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Dec 10 14:11:27 SAMT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/kotlin/v2/AmpliApp/settings.gradle
+++ b/android/kotlin/v2/AmpliApp/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 rootProject.name = "Ampli App"


### PR DESCRIPTION
## Summary

- Add `@Suppress("DEPRECATION")` to the generated `DefaultConfiguration` class — Amplitude-Kotlin 1.27.0 deprecated the `Configuration` constructor that accepts `trackingSessionEvents`/`defaultTracking`, and Kotlin resolves the wrapper's named-param call to that overload. Suppressing is appropriate for generated code and preserves full `[1.0.0, 2.0)` compat.
- Bump both Android V2 examples (Kotlin + Java) from AGP 7.0 / Gradle 7.0 to AGP 8.7.3 / Gradle 8.9 / compileSdk 34 — required by latest `analytics-android` 1.x transitive deps
- Split Android CI into V1 (JDK 11) and V2 (JDK 17) jobs — AGP 8 requires JDK 17

Refs: amplitude/Amplitude-Kotlin#381